### PR TITLE
Support Daydream

### DIFF
--- a/examples/supercraft/index.html
+++ b/examples/supercraft/index.html
@@ -15,13 +15,6 @@
         document.body.addEventListener('mousedown', () => { this.el.emit('shoot'); });
       }
     });
-
-    AFRAME.registerComponent('daydream', {
-      init: function () {
-        // Event fired by Daydream controller if present
-        this.el.addEventListener('trackpaddown', () => { this.el.emit('shoot'); });
-      }
-    });
   </script>
 </head>
 <body>
@@ -140,7 +133,7 @@
       vive-controls="hand: right; model: false;"
       oculus-touch-controls="hand: right; model: false;"
       daydream-controls="hand: right; model: false"
-      daydream
+      proxy-event__daydream="event: trackpaddown; to: #rightGun; as: triggerdown"
       proxy-event__shoot="event: triggerdown; to: #gunRight; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootRight; as: shoot"
       shooter="bulletTypes: normal; activeBulletType: normal">
@@ -154,7 +147,7 @@
       vive-controls="hand: left; model: false"
       oculus-touch-controls="hand: left; model: false"
       daydream-controls="hand: left; model: false"
-      daydream
+      proxy-event__daydream="event: trackpaddown; to: #leftGun; as: triggerdown"
       proxy-event__shoot="event: triggerdown; to: #gunLeft; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootLeft; as: shoot"
       shooter="bullets: normal; activeBulletType: normal">

--- a/examples/supercraft/index.html
+++ b/examples/supercraft/index.html
@@ -132,6 +132,7 @@
       id="rightGun"
       vive-controls="hand: right; model: false;"
       oculus-touch-controls="hand: right; model: false;"
+      daydream-controls="hand: right; model: false"
       proxy-event__shoot="event: triggerdown; to: #gunRight; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootRight; as: shoot"
       shooter="bulletTypes: normal; activeBulletType: normal">
@@ -144,6 +145,7 @@
       id="leftGun"
       vive-controls="hand: left; model: false"
       oculus-touch-controls="hand: left; model: false"
+      daydream-controls="hand: left; model: false"
       proxy-event__shoot="event: triggerdown; to: #gunLeft; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootLeft; as: shoot"
       shooter="bullets: normal; activeBulletType: normal">

--- a/examples/supercraft/index.html
+++ b/examples/supercraft/index.html
@@ -134,7 +134,7 @@
       oculus-touch-controls="hand: right; model: false;"
       daydream-controls="hand: right; model: false"
       proxy-event__daydream="event: trackpaddown; to: #rightGun; as: triggerdown"
-      proxy-event__shoot="event: triggerdown; to: #gunRight; as: shoot"
+      proxy-event__shoot="event: triggerdown; to: #rightGun; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootRight; as: shoot"
       shooter="bulletTypes: normal; activeBulletType: normal">
       <a-entity supercraft-thing="from: #supercraftThings; name: thing30; resetOrigin: true; ignorePosition: true" rotation="0 5 0" position="0 0 -0.03"></a-entity>
@@ -148,7 +148,7 @@
       oculus-touch-controls="hand: left; model: false"
       daydream-controls="hand: left; model: false"
       proxy-event__daydream="event: trackpaddown; to: #leftGun; as: triggerdown"
-      proxy-event__shoot="event: triggerdown; to: #gunLeft; as: shoot"
+      proxy-event__shoot="event: triggerdown; to: #leftGun; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootLeft; as: shoot"
       shooter="bullets: normal; activeBulletType: normal">
       <a-entity supercraft-thing="from: #supercraftThings; name: thing30; resetOrigin: true; ignorePosition: true" rotation="0 5 0" position="0 0 -0.03"></a-entity>

--- a/examples/supercraft/index.html
+++ b/examples/supercraft/index.html
@@ -15,6 +15,13 @@
         document.body.addEventListener('mousedown', () => { this.el.emit('shoot'); });
       }
     });
+
+    AFRAME.registerComponent('daydream', {
+      init: function () {
+        // Event fired by Daydream controller if present
+        this.el.addEventListener('trackpaddown', () => { this.el.emit('shoot'); });
+      }
+    });
   </script>
 </head>
 <body>
@@ -133,6 +140,7 @@
       vive-controls="hand: right; model: false;"
       oculus-touch-controls="hand: right; model: false;"
       daydream-controls="hand: right; model: false"
+      daydream
       proxy-event__shoot="event: triggerdown; to: #gunRight; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootRight; as: shoot"
       shooter="bulletTypes: normal; activeBulletType: normal">
@@ -146,6 +154,7 @@
       vive-controls="hand: left; model: false"
       oculus-touch-controls="hand: left; model: false"
       daydream-controls="hand: left; model: false"
+      daydream
       proxy-event__shoot="event: triggerdown; to: #gunLeft; as: shoot"
       proxy-event__shootsound="event: triggerdown; to: #soundShootLeft; as: shoot"
       shooter="bullets: normal; activeBulletType: normal">


### PR DESCRIPTION
This PR adds support for the Daydream controller.

I'm registering a component to listen for the `trackpaddown` event of the Daydream controller.
I tried proxying this event by adjusting the `proxy-event__shoot` attribute but without success. If you agree that this feature is worth being merged into master but the code needs any type of refactoring, please let me know and I'll gladly make the adjustments. I just started looking into WebVR and welcome any feedback :)

– Kevin