### PR TITLE
Emit "die" event after "hit"

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,8 +214,8 @@ AFRAME.registerSystem('bullet', {
           }
           if (isHit) {
             this.killBullet(bullet);
-            target.components.target.onBulletHit(bullet);
             target.emit('hit', null);
+            target.components.target.onBulletHit(bullet);
             break;
           }
         }


### PR DESCRIPTION
A target must be hit before it dies.
So, the 'hit' event should be emitted first.